### PR TITLE
Add active->inactive transition to prohibitions

### DIFF
--- a/src/main/java/npl/NPLInterpreter.java
+++ b/src/main/java/npl/NPLInterpreter.java
@@ -567,24 +567,21 @@ public class NPLInterpreter implements ToDOM {
             }            
         }
         
-        // -- transition active -> inactive (based on r for obl)
+        // -- transition active -> inactive (based on r for obl and pro)
         //                                  (based on w for per)
         private void updateInactive() {
-            active = getActive();            
-            for (DeonticModality o: active) { 
+            active = getActive();
+            for (DeonticModality o : active) {
                 Literal oasinbb = createState(o);
-                if (o.isObligation() && ! o.getMaitenanceCondition().logicalConsequence(ag, new Unifier()).hasNext()) {
+                if (((o.isObligation() || o.isProhibition()) && !holds(o.getMaitenanceCondition()))
+                        || (o.isPermission() && holds(o.getAim()))) {
                     // transition active -> inactive
-                    if (!bb.remove(oasinbb)) System.out.println("ooops "+oasinbb+" should be removed 1!");
+                    if (!bb.remove(oasinbb))
+                        System.out.println("ooops " + oasinbb + " should be removed 1!");
                     o.setInactive();
                     notifyInactive(o);
                 }
-                if (o.isPermission() && o.getAim().logicalConsequence(ag, new Unifier()).hasNext()) {
-                    if (!bb.remove(oasinbb)) System.out.println("ooops "+oasinbb+" should be removed 2!");
-                    o.setInactive();
-                    notifyInactive(o);                    
-                }
-            }            
+            }
         }
         
         // -- transition active -> unfulfilled (for obl) (based on d)


### PR DESCRIPTION
Previously, the prohibition in the following norm wouldn't work as expected:
```
norm n2: true
       -> prohibition(A,student(_,_), a(V) & V > 30 & setter(a,A), `never` ).
```
The prohibition is expected to be kept (for everybody) while there is a student. When there's no more students left, the prohibition should be deactivated. However, prohibitions never transitioned from active to inactive. This PR adds this transition.