### PR TITLE
Refactor Norm to allow easier extensions

### DIFF
--- a/src/main/java/npl/AbstractNorm.java
+++ b/src/main/java/npl/AbstractNorm.java
@@ -10,6 +10,9 @@ public abstract class AbstractNorm implements INorm {
 	protected Literal consequence;
 
 	@Override
+	public abstract AbstractNorm clone();
+
+	@Override
 	public String getId() {
 		return id;
 	}

--- a/src/main/java/npl/AbstractNorm.java
+++ b/src/main/java/npl/AbstractNorm.java
@@ -5,25 +5,25 @@ import jason.asSyntax.LogicalFormula;
 
 public abstract class AbstractNorm implements INorm {
 
-	protected String id;
-	protected LogicalFormula condition;
-	protected Literal consequence;
+    protected String id;
+    protected LogicalFormula condition;
+    protected Literal consequence;
 
-	@Override
-	public abstract AbstractNorm clone();
+    @Override
+    public abstract AbstractNorm clone();
 
-	@Override
-	public String getId() {
-		return id;
-	}
+    @Override
+    public String getId() {
+        return id;
+    }
 
-	@Override
-	public LogicalFormula getCondition() {
-		return condition;
-	}
+    @Override
+    public LogicalFormula getCondition() {
+        return condition;
+    }
 
-	@Override
-	public Literal getConsequence() {
-		return consequence;
-	}
+    @Override
+    public Literal getConsequence() {
+        return consequence;
+    }
 }

--- a/src/main/java/npl/AbstractNorm.java
+++ b/src/main/java/npl/AbstractNorm.java
@@ -1,0 +1,26 @@
+package npl;
+
+import jason.asSyntax.Literal;
+import jason.asSyntax.LogicalFormula;
+
+public abstract class AbstractNorm implements INorm {
+
+	protected String id;
+	protected LogicalFormula condition;
+	protected Literal consequence;
+
+	@Override
+	public String getId() {
+		return id;
+	}
+
+	@Override
+	public LogicalFormula getCondition() {
+		return condition;
+	}
+
+	@Override
+	public Literal getConsequence() {
+		return consequence;
+	}
+}

--- a/src/main/java/npl/DeonticModality.java
+++ b/src/main/java/npl/DeonticModality.java
@@ -19,56 +19,58 @@ import jason.asSyntax.VarTerm;
 /** The generic class for obligations, permissions, and prohibitions */
 public class DeonticModality extends LiteralImpl {
 
-    public enum State { none, active, fulfilled, unfulfilled, inactive } ;
+    public enum State {
+        none, active, fulfilled, unfulfilled, inactive
+    };
 
-    Norm n; // the norm that created this obligation
+    INorm n; // the norm that created this obligation
     Unifier u; // the unifier used in the activation of the norm
     State s = State.none;
-    int   agInstances = 0; // when the Ag is a var, this field count how many agent instances where latter created 
+    int agInstances = 0; // when the Ag is a var, this field count how many
+                            // agent instances where latter created
     boolean maintContFromNorm = false;
-    
+
     private static Unifier emptyUnif = new Unifier();
-    
-    public DeonticModality(Literal l, Unifier u, Norm n) {
+
+    public DeonticModality(Literal l, Unifier u, INorm n) {
         super(l.getFunctor());
         maintContFromNorm = l.getTerm(1).equals(n.getCondition());
-        
-        Literal lc = (Literal)l.capply(u);
-        //Unifier newu = new Unifier();
-        //newu.unifies(l.getTerm(0), lc.getTerm(0)); // unifies agent
-        //newu.unifies(l.getTerm(2), lc.getTerm(2)); // unifies aim, this unifier is used for the maint. cond.
+
+        Literal lc = (Literal) l.capply(u);
+        // Unifier newu = new Unifier();
+        // newu.unifies(l.getTerm(0), lc.getTerm(0)); // unifies agent
+        // newu.unifies(l.getTerm(2), lc.getTerm(2)); // unifies aim, this
+        // unifier is used for the maint. cond.
         addTerm(lc.getTerm(0));
-        //addTerm(l.getTerm(1).capply(newu));
+        // addTerm(l.getTerm(1).capply(newu));
         addTerm(lc.getTerm(1));
         addTerm(lc.getTerm(2));
         addTerm(lc.getTerm(3));
         if (lc.hasAnnot())
-            setAnnots( lc.getAnnots() );
+            setAnnots(lc.getAnnots());
         this.n = n;
         if (u == null)
             this.u = emptyUnif;
-        else 
+        else
             this.u = u.clone();
     }
-    
+
     // used by capply
     private DeonticModality(DeonticModality l, Unifier u) {
         super(l.getFunctor());
-        for (Term t: l.getTerms())
+        for (Term t : l.getTerms())
             addTerm(t.capply(u));
         if (l.hasAnnot())
-            setAnnots( (ListTerm)l.getAnnots().capply(u) );
-        /*Literal lc = (Literal)l.capply(u);
-        Unifier newu = new Unifier();
-        newu.unifies(l.getTerm(0), lc.getTerm(0)); // unifies agent
-        newu.unifies(l.getTerm(2), lc.getTerm(2)); // unifies aim, this unifier is used for the maint. cond.
-        addTerm(lc.getTerm(0));
-        addTerm(l.getTerm(1).capply(newu));
-        addTerm(lc.getTerm(2));
-        addTerm(lc.getTerm(3));
-        if (lc.hasAnnot())
-            setAnnots( lc.getAnnots() );
-        */
+            setAnnots((ListTerm) l.getAnnots().capply(u));
+        /*
+         * Literal lc = (Literal)l.capply(u); Unifier newu = new Unifier();
+         * newu.unifies(l.getTerm(0), lc.getTerm(0)); // unifies agent
+         * newu.unifies(l.getTerm(2), lc.getTerm(2)); // unifies aim, this
+         * unifier is used for the maint. cond. addTerm(lc.getTerm(0));
+         * addTerm(l.getTerm(1).capply(newu)); addTerm(lc.getTerm(2));
+         * addTerm(lc.getTerm(3)); if (lc.hasAnnot()) setAnnots( lc.getAnnots()
+         * );
+         */
 
         this.n = l.n;
         this.s = l.s;
@@ -76,7 +78,7 @@ public class DeonticModality extends LiteralImpl {
         u.compose(l.u);
         this.maintContFromNorm = l.maintContFromNorm;
     }
-    
+
     // used by copy
     private DeonticModality(DeonticModality d) {
         super(d);
@@ -85,147 +87,152 @@ public class DeonticModality extends LiteralImpl {
         this.u = d.u;
         this.maintContFromNorm = d.maintContFromNorm;
     }
-    
+
     /** returns the norms used to create this obligation */
-    public Norm getNorm() {
+    public INorm getNorm() {
         return n;
     }
-    
-    /** returns the unifier used to activate the norm used to create this obligation */
+
+    /**
+     * returns the unifier used to activate the norm used to create this
+     * obligation
+     */
     public Unifier getUnifier() {
         return u;
     }
-    
+
     public Literal getAg() {
-        return (Literal)getTerm(0);
+        return (Literal) getTerm(0);
     }
 
     public LogicalFormula getMaitenanceCondition() {
-        return (Literal)getTerm(1);
+        return (Literal) getTerm(1);
     }
-    
+
     public LogicalFormula getAim() {
-        return (LogicalFormula)getTerm(2);
+        return (LogicalFormula) getTerm(2);
     }
-    
+
     /** gets the deadline (in milliseconds) */
     public long getDeadline() {
         try {
-            return (long)((NumberTerm)getTerm(3)).solve();
+            return (long) ((NumberTerm) getTerm(3)).solve();
         } catch (NoValueException e) {
             e.printStackTrace();
             return 0;
         }
     }
-    
+
     public String getDoneStr() {
         long toff = -1;
         List<Term> al = getAnnots("done");
         if (!al.isEmpty()) {
-            Structure annot = (Structure)al.get(0);
+            Structure annot = (Structure) al.get(0);
             try {
-                toff = (long)((NumberTerm)annot.getTerm(0)).solve();
+                toff = (long) ((NumberTerm) annot.getTerm(0)).solve();
                 return TimeTerm.toAbsTimeStr(toff);
-            } catch (NoValueException e) {  }
+            } catch (NoValueException e) {
+            }
         }
         return null;
     }
-    
+
     public State getState() {
         return s;
     }
-    
+
     public void incAgInstance() {
         agInstances++;
     }
+
     public int getAgIntances() {
         return agInstances;
     }
-    
+
     public void setActive() {
         s = State.active;
-        addAnnot(ASSyntax.createStructure("created", new TimeTerm(0,null)));
-        addAnnot(ASSyntax.createStructure("norm", 
-                new Atom(n.getId()),
-                getUnifierAsTerm()));
+        addAnnot(ASSyntax.createStructure("created", new TimeTerm(0, null)));
+        addAnnot(ASSyntax.createStructure("norm", new Atom(n.getId()), getUnifierAsTerm()));
     }
-    
+
     public ListTerm getUnifierAsTerm() {
         ListTerm lf = new ListTermImpl();
         ListTerm tail = lf;
-        for (VarTerm k: u) {
-            if (! k.isUnnamedVar()) {
+        for (VarTerm k : u) {
+            if (!k.isUnnamedVar()) {
                 Term vl = u.get(k);
-                tail = tail.append(ASSyntax.createList(
-                        ASSyntax.createString(k), 
-                        vl));
+                tail = tail.append(ASSyntax.createList(ASSyntax.createString(k), vl));
             }
         }
         return lf;
     }
-    
+
     public void setFulfilled() {
         s = State.fulfilled;
-        long ttf = System.currentTimeMillis()-getDeadline();
+        long ttf = System.currentTimeMillis() - getDeadline();
         addAnnot(ASSyntax.createStructure("done", ASSyntax.createNumber(ttf)));
-        addAnnot(ASSyntax.createStructure("fulfilled", new TimeTerm(0,null)));
+        addAnnot(ASSyntax.createStructure("fulfilled", new TimeTerm(0, null)));
     }
 
     public void setUnfulfilled() {
         s = State.unfulfilled;
-        addAnnot(ASSyntax.createStructure("unfulfilled", new TimeTerm(0,null)));
+        addAnnot(ASSyntax.createStructure("unfulfilled", new TimeTerm(0, null)));
     }
-    
+
     public void setInactive() {
         s = State.inactive;
-        addAnnot(ASSyntax.createStructure("inactive", new TimeTerm(0,null)));
+        addAnnot(ASSyntax.createStructure("inactive", new TimeTerm(0, null)));
     }
-    
 
     public boolean equalsIgnoreDeadline(DeonticModality o) {
-        return getFunctor().equals(o.getFunctor()) &&
-               getAg().equals(o.getAg()) && 
-               //getReason().equals(o.getReason()) && 
-               getAim().equals(o.getAim());
+        return getFunctor().equals(o.getFunctor()) && getAg().equals(o.getAg()) &&
+        // getReason().equals(o.getReason()) &&
+                getAim().equals(o.getAim());
     }
-    
+
     public DeonticModality capply(Unifier u) {
         return new DeonticModality(this, u);
     }
+
     public DeonticModality copy() {
         return new DeonticModality(this);
     }
-    
+
     @Override
     public Term clone() {
         return copy();
     }
-    
-    public boolean isObligation()  { return getFunctor().equals(NormativeProgram.OblFunctor); } 
-    public boolean isPermission()  { return getFunctor().equals(NormativeProgram.PerFunctor); } 
-    public boolean isProhibition() { return getFunctor().equals(NormativeProgram.ProFunctor); } 
 
-    
+    public boolean isObligation() {
+        return getFunctor().equals(NormativeProgram.OblFunctor);
+    }
+
+    public boolean isPermission() {
+        return getFunctor().equals(NormativeProgram.PerFunctor);
+    }
+
+    public boolean isProhibition() {
+        return getFunctor().equals(NormativeProgram.ProFunctor);
+    }
+
     @Override
     public String toString() {
         StringBuilder so = new StringBuilder();
-        so.append(getFunctor()+"("+getAg()+",");
-        //if (maintContFromNorm)
-        //    so.append(getNorm().getId());
-        //else
+        so.append(getFunctor() + "(" + getAg() + ",");
+        // if (maintContFromNorm)
+        // so.append(getNorm().getId());
+        // else
         so.append(getMaitenanceCondition());
-        so.append(","+getAim()+",\"");
-        if (s == State.active) {
-            so.append(TimeTerm.toRelTimeStr( getDeadline()));
-        } else { // if (s == State.fulfilled) {
-            so.append(TimeTerm.toTimeStamp( getDeadline()));
-        }
-        so.append("\")");
+        so.append("," + getAim() + ",\"");
+		if (s == State.active) {
+			so.append(TimeTerm.toRelTimeStr(getDeadline()));
+		} else { // if (s == State.fulfilled) {
+			so.append(TimeTerm.toTimeStamp(getDeadline()));
+		}
+		so.append("\")");
         if (hasAnnot()) {
             so.append(getAnnots());
         }
         return so.toString();
     }
-    
 }
-

--- a/src/main/java/npl/INorm.java
+++ b/src/main/java/npl/INorm.java
@@ -1,0 +1,35 @@
+package npl;
+
+import jason.asSyntax.Literal;
+import jason.asSyntax.LogicalFormula;
+
+/**
+ * @author igorcadelima
+ *
+ */
+public interface INorm {
+
+	/**
+	 * Returns the id of the norm which was assigned at creation.
+	 * 
+	 * @return id
+	 */
+	public String getId();
+
+	/**
+	 * Returns formula that determines the activation condition for the norm.
+	 * 
+	 * @return activation condition
+	 */
+	public LogicalFormula getCondition();
+
+	/**
+	 * Returns consequence of the norm activation as a {@link Literal}. It could
+	 * be an obligation, permission, prohibition, or failure.
+	 * 
+	 * @return consequence
+	 * @see DeonticModality
+	 */
+	public Literal getConsequence();
+
+}

--- a/src/main/java/npl/INorm.java
+++ b/src/main/java/npl/INorm.java
@@ -9,28 +9,28 @@ import jason.asSyntax.LogicalFormula;
  */
 public interface INorm {
 
-	public INorm clone();
-	
-	/**
-	 * Returns the id of the norm which was assigned at creation.
-	 * 
-	 * @return id
-	 */
-	public String getId();
+    public INorm clone();
+    
+    /**
+     * Returns the id of the norm which was assigned at creation.
+     * 
+     * @return id
+     */
+    public String getId();
 
-	/**
-	 * Returns formula that determines the activation condition for the norm.
-	 * 
-	 * @return activation condition
-	 */
-	public LogicalFormula getCondition();
+    /**
+     * Returns formula that determines the activation condition for the norm.
+     * 
+     * @return activation condition
+     */
+    public LogicalFormula getCondition();
 
-	/**
-	 * Returns consequence of the norm activation as a {@link Literal}. It could
-	 * be an obligation, permission, prohibition, or failure.
-	 * 
-	 * @return consequence
-	 * @see DeonticModality
-	 */
-	public Literal getConsequence();
+    /**
+     * Returns consequence of the norm activation as a {@link Literal}. It could
+     * be an obligation, permission, prohibition, or failure.
+     * 
+     * @return consequence
+     * @see DeonticModality
+     */
+    public Literal getConsequence();
 }

--- a/src/main/java/npl/INorm.java
+++ b/src/main/java/npl/INorm.java
@@ -9,6 +9,8 @@ import jason.asSyntax.LogicalFormula;
  */
 public interface INorm {
 
+	public INorm clone();
+	
 	/**
 	 * Returns the id of the norm which was assigned at creation.
 	 * 
@@ -31,5 +33,4 @@ public interface INorm {
 	 * @see DeonticModality
 	 */
 	public Literal getConsequence();
-
 }

--- a/src/main/java/npl/NPLInterpreter.java
+++ b/src/main/java/npl/NPLInterpreter.java
@@ -42,8 +42,8 @@ import org.w3c.dom.Element;
 public class NPLInterpreter implements ToDOM {
 
     private Agent            ag = null; // use a Jason agent to store the facts (BB)
-    private Map<String,Norm> regimentedNorms = null; // norms with failure consequence
-    private Map<String,Norm> regulativeNorms  = null; // norms with obligation, permission, prohibition consequence
+    private Map<String,INorm> regimentedNorms = null; // norms with failure consequence
+    private Map<String,INorm> regulativeNorms  = null; // norms with obligation, permission, prohibition consequence
 
     private Object           syncTransState = new Object();
     
@@ -64,8 +64,8 @@ public class NPLInterpreter implements ToDOM {
     
     public void init() {
         ag              = new Agent();
-        regimentedNorms = new HashMap<String,Norm>();
-        regulativeNorms = new HashMap<String,Norm>();
+        regimentedNorms = new HashMap<String,INorm>();
+        regulativeNorms = new HashMap<String,INorm>();
         ag.initAg();
         clearFacts();
         oblUpdateThread = new StateTransitions();
@@ -107,7 +107,7 @@ public class NPLInterpreter implements ToDOM {
             l.addSource(NPAtom);
             bb.add(1,l); // add in the end of the BB to preserve the program order
         }
-        for (Norm n: scope.getNorms()) {
+        for (INorm n: scope.getNorms()) {
             
             // auto id management
             String id = n.getId();
@@ -116,7 +116,7 @@ public class NPLInterpreter implements ToDOM {
                     while (getNorm(id) != null)
                         id = id + id;
                 } else {
-                    logger.warning("Norm with id "+id+" already exists! It will be replaced by "+n);
+                    logger.warning("INorm with id "+id+" already exists! It will be replaced by "+n);
                 }                    
             }
 
@@ -226,8 +226,8 @@ public class NPLInterpreter implements ToDOM {
         }
     }
     
-    public Norm getNorm(String id) {
-        Norm n = regulativeNorms.get(id);
+    public INorm getNorm(String id) {
+        INorm n = regulativeNorms.get(id);
         if (n != null)
             return n;
         else
@@ -244,7 +244,7 @@ public class NPLInterpreter implements ToDOM {
         List<DeonticModality> newObl = new ArrayList<DeonticModality>();
         synchronized (syncTransState) {            
             // test all fails first
-            for (Norm n: regimentedNorms.values()) {
+            for (INorm n: regimentedNorms.values()) {
                 Iterator<Unifier> i = n.getCondition().logicalConsequence(ag, new Unifier());
                 while (i.hasNext()) {
                     Unifier u = i.next();
@@ -260,7 +260,7 @@ public class NPLInterpreter implements ToDOM {
             List<DeonticModality> activeObl = getActive();
             
             // -- computes new obligations, permissions, and prohibitions
-            for (Norm n: regulativeNorms.values()) {
+            for (INorm n: regulativeNorms.values()) {
                 Iterator<Unifier> i = n.getCondition().logicalConsequence(ag, new Unifier());
                 while (i.hasNext()) {
                     Unifier u = i.next();
@@ -362,9 +362,9 @@ public class NPLInterpreter implements ToDOM {
     
     public String getNormsString() {
         StringBuilder out = new StringBuilder();
-        for (Norm n: regimentedNorms.values()) 
+        for (INorm n: regimentedNorms.values()) 
             out.append(n+".\n");
-        for (Norm n: regulativeNorms.values()) 
+        for (INorm n: regulativeNorms.values()) 
             out.append(n+".\n");
         return out.toString();
     }

--- a/src/main/java/npl/Norm.java
+++ b/src/main/java/npl/Norm.java
@@ -5,24 +5,25 @@ import jason.asSyntax.LogicalFormula;
 
 public class Norm extends AbstractNorm {
 
-	public Norm(String id, Literal consequence, LogicalFormula condition) {
-		if (!consequence.getFunctor().equals(NormativeProgram.FailFunctor)) {
-			if (((Literal) consequence.getTerm(1)).getFunctor().toString().equals(id)) {
-				consequence.setTerm(1, condition);
-			}
-		}
-		this.id = id;
-		this.consequence = consequence;
-		this.condition = condition;
-	}
+    public Norm(String id, Literal consequence, LogicalFormula condition) {
+        if (!consequence.getFunctor().equals(NormativeProgram.FailFunctor)) {
+            if (((Literal) consequence.getTerm(1)).getFunctor().toString().equals(id)) {
+                consequence.setTerm(1, condition);
+            }
+        }
+        this.id = id;
+        this.consequence = consequence;
+        this.condition = condition;
+    }
 
-	public Norm clone() {
-		return new Norm(id, consequence.copy(), (LogicalFormula) condition.clone());
-	}
+    @Override
+    public Norm clone() {
+        return new Norm(id, consequence.copy(), (LogicalFormula) condition.clone());
+    }
 
-	@Override
-	public String toString() {
-		return "norm " + id + ": " + condition + " -> " + consequence;
-	}
+    @Override
+    public String toString() {
+        return "norm " + id + ": " + condition + " -> " + consequence;
+    }
 
 }

--- a/src/main/java/npl/Norm.java
+++ b/src/main/java/npl/Norm.java
@@ -12,20 +12,38 @@ public class Norm extends AbstractNorm {
      * argument.
      * 
      * @param id
-     *            Norm's id
+     *            norm's id
      * @param consequence
-     *            Norm's consequence
+     *            norm's consequence
      * @param condition
-     *            Norm's activation condition
+     *            norm's activation condition
+     */
+    public static NormFactory getFactory() {
+        return new NormFactory() {
+            public Norm createNorm(String id, Literal consequence, LogicalFormula activationCondition) {
+                boolean consequenceIsFailure = consequence.getFunctor().equals(NormativeProgram.FailFunctor);
+                if (!consequenceIsFailure) {
+                    String maintenanceConditionFunctor = ((Literal) consequence.getTerm(1)).getFunctor();
+                    if (maintenanceConditionFunctor.equals(id)) {
+                        consequence.setTerm(1, activationCondition);
+                    }
+                }
+                return new Norm(id, consequence, activationCondition);
+            }
+        };
+    }
+
+    /**
+     * Creates a norm based on the arguments' value without any modification.
+     * 
+     * @param id
+     *            norm's id
+     * @param consequence
+     *            norm's consequence
+     * @param condition
+     *            norm's activation condition
      */
     public Norm(String id, Literal consequence, LogicalFormula condition) {
-        boolean consequenceIsFailure = consequence.getFunctor().equals(NormativeProgram.FailFunctor);
-        if (!consequenceIsFailure) {
-            String maintenanceConditionFunctor = ((Literal) consequence.getTerm(1)).getFunctor();
-            if (maintenanceConditionFunctor.equals(id)) {
-                consequence.setTerm(1, condition);
-            }
-        }
         this.id = id;
         this.consequence = consequence;
         this.condition = condition;
@@ -34,10 +52,5 @@ public class Norm extends AbstractNorm {
     @Override
     public Norm clone() {
         return new Norm(id, consequence.copy(), (LogicalFormula) condition.clone());
-    }
-
-    @Override
-    public String toString() {
-        return "norm " + id + ": " + condition + " -> " + consequence;
     }
 }

--- a/src/main/java/npl/Norm.java
+++ b/src/main/java/npl/Norm.java
@@ -5,39 +5,39 @@ import jason.asSyntax.LogicalFormula;
 
 public class Norm extends AbstractNorm {
 
-	/**
-	 * Creates a norm based on the given arguments. If consequence is not a
-	 * failure and maintenance condition's functor is equal to the norm's id,
-	 * then consequence's maintenance condition becomes the condition passed as
-	 * argument.
-	 * 
-	 * @param id
-	 *            Norm's id
-	 * @param consequence
-	 *            Norm's consequence
-	 * @param condition
-	 *            Norm's activation condition
-	 */
-	public Norm(String id, Literal consequence, LogicalFormula condition) {
-		boolean consequenceIsFailure = consequence.getFunctor().equals(NormativeProgram.FailFunctor);
-		if (!consequenceIsFailure) {
-			String maintenanceConditionFunctor = ((Literal) consequence.getTerm(1)).getFunctor();
-			if (maintenanceConditionFunctor.equals(id)) {
-				consequence.setTerm(1, condition);
-			}
-		}
-		this.id = id;
-		this.consequence = consequence;
-		this.condition = condition;
-	}
+    /**
+     * Creates a norm based on the given arguments. If consequence is not a
+     * failure and maintenance condition's functor is equal to the norm's id,
+     * then consequence's maintenance condition becomes the condition passed as
+     * argument.
+     * 
+     * @param id
+     *            Norm's id
+     * @param consequence
+     *            Norm's consequence
+     * @param condition
+     *            Norm's activation condition
+     */
+    public Norm(String id, Literal consequence, LogicalFormula condition) {
+        boolean consequenceIsFailure = consequence.getFunctor().equals(NormativeProgram.FailFunctor);
+        if (!consequenceIsFailure) {
+            String maintenanceConditionFunctor = ((Literal) consequence.getTerm(1)).getFunctor();
+            if (maintenanceConditionFunctor.equals(id)) {
+                consequence.setTerm(1, condition);
+            }
+        }
+        this.id = id;
+        this.consequence = consequence;
+        this.condition = condition;
+    }
 
-	@Override
-	public Norm clone() {
-		return new Norm(id, consequence.copy(), (LogicalFormula) condition.clone());
-	}
+    @Override
+    public Norm clone() {
+        return new Norm(id, consequence.copy(), (LogicalFormula) condition.clone());
+    }
 
-	@Override
-	public String toString() {
-		return "norm " + id + ": " + condition + " -> " + consequence;
-	}
+    @Override
+    public String toString() {
+        return "norm " + id + ": " + condition + " -> " + consequence;
+    }
 }

--- a/src/main/java/npl/Norm.java
+++ b/src/main/java/npl/Norm.java
@@ -5,25 +5,39 @@ import jason.asSyntax.LogicalFormula;
 
 public class Norm extends AbstractNorm {
 
-    public Norm(String id, Literal consequence, LogicalFormula condition) {
-        if (!consequence.getFunctor().equals(NormativeProgram.FailFunctor)) {
-            if (((Literal) consequence.getTerm(1)).getFunctor().toString().equals(id)) {
-                consequence.setTerm(1, condition);
-            }
-        }
-        this.id = id;
-        this.consequence = consequence;
-        this.condition = condition;
-    }
+	/**
+	 * Creates a norm based on the given arguments. If consequence is not a
+	 * failure and maintenance condition's functor is equal to the norm's id,
+	 * then consequence's maintenance condition becomes the condition passed as
+	 * argument.
+	 * 
+	 * @param id
+	 *            Norm's id
+	 * @param consequence
+	 *            Norm's consequence
+	 * @param condition
+	 *            Norm's activation condition
+	 */
+	public Norm(String id, Literal consequence, LogicalFormula condition) {
+		boolean consequenceIsFailure = consequence.getFunctor().equals(NormativeProgram.FailFunctor);
+		if (!consequenceIsFailure) {
+			String maintenanceConditionFunctor = ((Literal) consequence.getTerm(1)).getFunctor();
+			if (maintenanceConditionFunctor.equals(id)) {
+				consequence.setTerm(1, condition);
+			}
+		}
+		this.id = id;
+		this.consequence = consequence;
+		this.condition = condition;
+	}
 
-    @Override
-    public Norm clone() {
-        return new Norm(id, consequence.copy(), (LogicalFormula) condition.clone());
-    }
+	@Override
+	public Norm clone() {
+		return new Norm(id, consequence.copy(), (LogicalFormula) condition.clone());
+	}
 
-    @Override
-    public String toString() {
-        return "norm " + id + ": " + condition + " -> " + consequence;
-    }
-
+	@Override
+	public String toString() {
+		return "norm " + id + ": " + condition + " -> " + consequence;
+	}
 }

--- a/src/main/java/npl/Norm.java
+++ b/src/main/java/npl/Norm.java
@@ -5,47 +5,40 @@ import jason.asSyntax.LogicalFormula;
 
 public class Norm {
 
-    // used by the parser
-    public static NormFactory getFactory() {
-        return new NormFactory() {
-            public Norm createNorm(String id, Literal consequence, LogicalFormula activationCondition) {
-                if (!consequence.getFunctor().equals(NormativeProgram.FailFunctor)) {
-                    if ( ((Literal)consequence.getTerm(1)).getFunctor().toString().equals(id)) {
-                        consequence.setTerm(1, activationCondition);
-                    }
-                }
-                return new Norm(id,consequence,activationCondition);
-            }
-        };
-    }    
+	private String id;
+	private Literal consequence;
+	private LogicalFormula condition;
 
-    private String id;
-    private Literal consequence;
-    private LogicalFormula condition;
-    
-    public Norm(String id, Literal head, LogicalFormula body) {
-        this.id = id;
-        this.consequence = head;
-        this.condition = body;
-    }
-    
-    public String getId() {
-        return id;
-    }
-    public Literal getConsequence() {
-        return consequence;
-    }
-    public LogicalFormula getCondition() {
-        return condition;
-    }
-    
-    public Norm clone() {
-        return new Norm(id, consequence.copy(), (LogicalFormula)condition.clone());
-    }
-    
-    @Override
-    public String toString() {
-        return "norm " + id + ": " + condition + " -> " + consequence;
-    }
-    
+	public Norm(String id, Literal consequence, LogicalFormula condition) {
+		if (!consequence.getFunctor().equals(NormativeProgram.FailFunctor)) {
+			if (((Literal) consequence.getTerm(1)).getFunctor().toString().equals(id)) {
+				consequence.setTerm(1, condition);
+			}
+		}
+		this.id = id;
+		this.consequence = consequence;
+		this.condition = condition;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public Literal getConsequence() {
+		return consequence;
+	}
+
+	public LogicalFormula getCondition() {
+		return condition;
+	}
+
+	public Norm clone() {
+		return new Norm(id, consequence.copy(), (LogicalFormula) condition.clone());
+	}
+
+	@Override
+	public String toString() {
+		return "norm " + id + ": " + condition + " -> " + consequence;
+	}
+
 }

--- a/src/main/java/npl/Norm.java
+++ b/src/main/java/npl/Norm.java
@@ -3,11 +3,7 @@ package npl;
 import jason.asSyntax.Literal;
 import jason.asSyntax.LogicalFormula;
 
-public class Norm {
-
-	private String id;
-	private Literal consequence;
-	private LogicalFormula condition;
+public class Norm extends AbstractNorm {
 
 	public Norm(String id, Literal consequence, LogicalFormula condition) {
 		if (!consequence.getFunctor().equals(NormativeProgram.FailFunctor)) {
@@ -18,18 +14,6 @@ public class Norm {
 		this.id = id;
 		this.consequence = consequence;
 		this.condition = condition;
-	}
-
-	public String getId() {
-		return id;
-	}
-
-	public Literal getConsequence() {
-		return consequence;
-	}
-
-	public LogicalFormula getCondition() {
-		return condition;
 	}
 
 	public Norm clone() {

--- a/src/main/java/npl/NormFactory.java
+++ b/src/main/java/npl/NormFactory.java
@@ -1,0 +1,8 @@
+package npl;
+
+import jason.asSyntax.Literal;
+import jason.asSyntax.LogicalFormula;
+
+public interface NormFactory {
+    public Norm createNorm(String id, Literal consequence, LogicalFormula activationCondition);
+}

--- a/src/main/java/npl/NormFactory.java
+++ b/src/main/java/npl/NormFactory.java
@@ -1,8 +1,0 @@
-package npl;
-
-import jason.asSyntax.Literal;
-import jason.asSyntax.LogicalFormula;
-
-public interface NormFactory {
-    public Norm createNorm(String id, Literal consequence, LogicalFormula activationCondition);
-}

--- a/src/main/java/npl/Scope.java
+++ b/src/main/java/npl/Scope.java
@@ -14,7 +14,7 @@ public class Scope {
     private List<Rule>    rules = new ArrayList<Rule>();
     private Scope         father = null;
     private NormativeProgram   program = null;
-    private Map<String,Norm>   norms  = new HashMap<String,Norm>();
+    private Map<String,INorm>   norms  = new HashMap<String,INorm>();
     private Map<Literal,Scope> scopes = new HashMap<Literal,Scope>();
     
     public Scope(Literal id, NormativeProgram np) {
@@ -35,16 +35,16 @@ public class Scope {
         return rules;
     }
     
-    public void addNorm(Norm n) {
+    public void addNorm(INorm n) {
         norms.put(n.getId(),n);
     }
-    public Norm removeNorm(String id) {
+    public INorm removeNorm(String id) {
         return norms.remove(id);
     }
-    public Collection<Norm> getNorms() {
+    public Collection<INorm> getNorms() {
         return norms.values();
     }
-    public Norm getNorm(String id) {
+    public INorm getNorm(String id) {
         return norms.get(id);
     }
     
@@ -95,7 +95,7 @@ public class Scope {
         out.append(s+"scope "+id+" {\n");
         for (Rule r: rules) 
             out.append(s+"  "+r+".\n");
-        for (Norm n: norms.values()) 
+        for (INorm n: norms.values()) 
             out.append(s+"  "+n+".\n");
         for (Scope sc: scopes.values()) 
             out.append("\n"+sc);

--- a/src/main/javacc/npl.jj
+++ b/src/main/javacc/npl.jj
@@ -128,7 +128,7 @@ void program(NormativeProgram np, DynamicFactsProvider dfp) :
 
 
 void scope(NormativeProgram np, Scope superScope) : 
-{ Literal scopeId; Rule r; Norm n; Scope scope;  }
+{ Literal scopeId; Rule r; INorm n; Scope scope;  }
 { <SCOPE> scopeId = literal() 
                               { scope = new Scope(scopeId, np);
                                 if (superScope == null) { // it is root
@@ -153,7 +153,7 @@ Rule rule() :
                               { return new Rule(h,(LogicalFormula)b); } 
 }
 
-Norm norm() : 
+INorm norm() : 
 { Literal h; Object b; Token id; }
 { <NORM> id = <ATOM> ":"
   b = log_expr() 

--- a/src/main/javacc/npl.jj
+++ b/src/main/javacc/npl.jj
@@ -24,9 +24,13 @@ PARSER_BEGIN(nplp) // NPL parser
     private String npSource = null;
     private DynamicFactsProvider dfp;
     private static LiteralFactory lFac = NPLLiteral.getFactory();
+    private static NormFactory    nFac = Norm.getFactory();
 
     public static void setLiteralFactory(LiteralFactory l) {
         lFac = l; 
+    } 
+    public static void setNormFactory(NormFactory l) {
+        nFac = l; 
     } 
     
     private String getSourceRef(SourceInfo s) {
@@ -162,7 +166,7 @@ INorm norm() :
                        {
                          if (b.toString().equals("true"))  b = Literal.LTrue;  
                          if (b.toString().equals("false")) b = Literal.LFalse;  
-                         return new Norm(id.image,h,(LogicalFormula)b); 
+                         return nFac.createNorm(id.image,h,(LogicalFormula)b); 
                        }   
 }
 

--- a/src/main/javacc/npl.jj
+++ b/src/main/javacc/npl.jj
@@ -24,13 +24,9 @@ PARSER_BEGIN(nplp) // NPL parser
     private String npSource = null;
     private DynamicFactsProvider dfp;
     private static LiteralFactory lFac = NPLLiteral.getFactory();
-    private static NormFactory    nFac = Norm.getFactory();
 
     public static void setLiteralFactory(LiteralFactory l) {
         lFac = l; 
-    } 
-    public static void setNormFactory(NormFactory l) {
-        nFac = l; 
     } 
     
     private String getSourceRef(SourceInfo s) {
@@ -166,7 +162,7 @@ Norm norm() :
                        {
                          if (b.toString().equals("true"))  b = Literal.LTrue;  
                          if (b.toString().equals("false")) b = Literal.LFalse;  
-                         return nFac.createNorm(id.image,h,(LogicalFormula)b); 
+                         return new Norm(id.image,h,(LogicalFormula)b); 
                        }   
 }
 

--- a/src/test/java/NPLParserTest.java
+++ b/src/test/java/NPLParserTest.java
@@ -6,7 +6,7 @@ import jason.asSyntax.Literal;
 import jason.asSyntax.VarTerm;
 import junit.framework.TestCase;
 import npl.DeonticModality;
-import npl.Norm;
+import npl.INorm;
 import npl.NormativeProgram;
 import npl.Scope;
 import npl.parser.ParseException;
@@ -46,7 +46,7 @@ public class NPLParserTest extends TestCase {
         Literal o = p.getRoot().getScope(ASSyntax.parseLiteral("group(wp)")).getNorm("n2").getConsequence();
         assertEquals("(vl(X) & (Y > 10))", o.getTerm(1).toString());
 
-        Norm n2 = p.getRoot().findScope("group(wp)").getNorm("n2");
+        INorm n2 = p.getRoot().findScope("group(wp)").getNorm("n2");
         assertNotNull(n2);
         Unifier u = new Unifier();
         u.unifies(new VarTerm("X"), ASSyntax.createNumber(10));


### PR DESCRIPTION
The following changes were made to allow easier creation of classes with the same interface as the Norm class:

- Remove NormFactory due to no real need for it and unsuitability if aiming to allow extensions of Norm
- Add INorm interface with essential methods for norms
- Add AbstractNorm, which implements INorm, with base functionality of Norm
- Refactor Norm and make it an extension of AbstractNorm
- Replace declarations/returns of Norm with INorm